### PR TITLE
Add WebSocket search suggestions

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -35,16 +35,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-log4j2</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                        <exclusions>
+                                <exclusion>
+                                        <groupId>org.springframework.boot</groupId>
+                                        <artifactId>spring-boot-starter-logging</artifactId>
+                                </exclusion>
+                        </exclusions>
+                </dependency>
+
+                <!-- WebSocket support for live search suggestions -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-websocket</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/novel/vippro/Config/WebSocketConfig.java
+++ b/backend/src/main/java/com/novel/vippro/Config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.novel.vippro.Config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * Basic STOMP over WebSocket configuration used by the search suggestion
+ * feature. Exposes an endpoint that the frontend can connect to and enables a
+ * simple broker for topics.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/backend/src/main/java/com/novel/vippro/Controllers/SearchSocketController.java
+++ b/backend/src/main/java/com/novel/vippro/Controllers/SearchSocketController.java
@@ -1,0 +1,68 @@
+package com.novel.vippro.Controllers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import com.novel.vippro.DTO.Novel.NovelDTO;
+import com.novel.vippro.Payload.Response.PageResponse;
+import com.novel.vippro.Services.NovelService;
+
+/**
+ * Handles live search requests over WebSocket. Incoming search queries are
+ * debounced on the client but we additionally cancel any in-flight search on
+ * the server to avoid returning stale results when a user types quickly.
+ */
+@Controller
+public class SearchSocketController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final NovelService novelService;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final Map<String, Future<?>> inFlight = new ConcurrentHashMap<>();
+
+    @Autowired
+    public SearchSocketController(SimpMessagingTemplate messagingTemplate, NovelService novelService) {
+        this.messagingTemplate = messagingTemplate;
+        this.novelService = novelService;
+    }
+
+    /**
+     * Receives search queries and streams the top matching novels to a
+     * session-scoped topic. Any previous search for the same session is
+     * cancelled to prevent outdated results from being sent.
+     */
+    @MessageMapping("/search")
+    public void handleSearch(String query, @Header("simpSessionId") String sessionId) {
+        // cancel any previous search for this session
+        Future<?> previous = inFlight.remove(sessionId);
+        if (previous != null) {
+            previous.cancel(true);
+        }
+
+        // if query is blank send empty suggestion list
+        if (query == null || query.isBlank()) {
+            messagingTemplate.convertAndSend("/topic/search", List.of());
+            return;
+        }
+
+        Future<?> task = executor.submit(() -> {
+            Pageable pageable = PageRequest.of(0, 5); // limit suggestions
+            PageResponse<NovelDTO> page = novelService.searchNovels(query, pageable);
+            messagingTemplate.convertAndSend("/topic/search", page.getContent());
+        });
+
+        inFlight.put(sessionId, task);
+    }
+}

--- a/frontend/components/SearchBar.tsx
+++ b/frontend/components/SearchBar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Client, IMessage } from '@stomp/stompjs';
+import { Input } from '@/components/ui/input';
+
+/**
+ * Search bar component that communicates with the backend over a WebSocket
+ * connection. Queries are debounced before being sent and results are rendered
+ * in a dropdown below the input.
+ */
+export default function SearchBar() {
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const clientRef = useRef<Client | null>(null);
+  const timeout = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    const client = new Client({
+      brokerURL: process.env.NEXT_PUBLIC_BACKEND_WS || 'ws://localhost:8080/ws',
+    });
+
+    client.onConnect = () => {
+      client.subscribe('/topic/search', (message: IMessage) => {
+        try {
+          const data = JSON.parse(message.body) as any[];
+          if (Array.isArray(data)) {
+            const titles = data.map((item) => (typeof item === 'string' ? item : item.title));
+            setSuggestions(titles);
+          }
+        } catch {
+          setSuggestions([]);
+        }
+      });
+    };
+
+    client.activate();
+    clientRef.current = client;
+    return () => client.deactivate();
+  }, []);
+
+  const sendQuery = (q: string) => {
+    const client = clientRef.current;
+    if (client && client.connected) {
+      client.publish({ destination: '/app/search', body: q });
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setQuery(value);
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => sendQuery(value), 300);
+  };
+
+  return (
+    <div className="relative w-full">
+      <Input value={query} onChange={handleChange} placeholder="Search novels..." />
+      {suggestions.length > 0 && (
+        <ul className="absolute z-10 mt-1 w-full rounded-md border bg-background shadow">
+          {suggestions.map((s, i) => (
+            <li
+              key={i}
+              className="cursor-pointer px-3 py-2 hover:bg-accent"
+              onMouseDown={() => setQuery(s)}
+            >
+              {s}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "input-otp": "latest",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
+    "@stomp/stompjs": "^7.0.0",
     "next-themes": "latest",
     "react": "^19",
     "react-day-picker": "latest",


### PR DESCRIPTION
## Summary
- enable WebSocket messaging and configure STOMP endpoint
- stream live search suggestions with cancelable backend tasks
- add debounced frontend SearchBar using WebSocket suggestions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689eb07ff8d883328815e1132190e9c7