### PR TITLE
Add multi-criteria novel search filters

### DIFF
--- a/backend/src/main/java/com/novel/vippro/Controllers/NovelController.java
+++ b/backend/src/main/java/com/novel/vippro/Controllers/NovelController.java
@@ -3,6 +3,7 @@ package com.novel.vippro.Controllers;
 import com.novel.vippro.DTO.Comment.CommentDTO;
 import com.novel.vippro.DTO.Novel.NovelCreateDTO;
 import com.novel.vippro.DTO.Novel.NovelDTO;
+import com.novel.vippro.DTO.Novel.NovelSearchDTO;
 import com.novel.vippro.Models.Chapter;
 import com.novel.vippro.Payload.Response.ControllerResponse;
 import com.novel.vippro.Payload.Response.PageResponse;
@@ -166,20 +167,20 @@ public class NovelController {
         return ControllerResponse.success("Novels retrieved successfully", novels);
     }
 
-    @Operation(summary = "Search novels", description = "Search novels by keyword in title and description")
+    @Operation(summary = "Search novels", description = "Search novels by combining keyword, title, author, category, or genre filters")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Search completed successfully")
     })
     @GetMapping("/search")
     public ControllerResponse<PageResponse<NovelDTO>> searchNovels(
-            @Parameter(description = "Search keyword") @RequestParam String keyword,
+            @Parameter(description = "Search filters") @ModelAttribute NovelSearchDTO searchDTO,
             @Parameter(description = "Page number") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Items per page") @RequestParam(defaultValue = "10") int size,
             @Parameter(description = "Sort field") @RequestParam(defaultValue = "updatedAt") String sortBy,
             @Parameter(description = "Sort direction") @RequestParam(defaultValue = "desc") String sortDir) {
         Sort sort = Sort.by(Sort.Direction.fromString(sortDir), sortBy);
         Pageable pageable = PageRequest.of(page, size, sort);
-        PageResponse<NovelDTO> novels = novelService.searchNovels(keyword, pageable);
+        PageResponse<NovelDTO> novels = novelService.searchNovels(searchDTO, pageable);
         return ControllerResponse.success("Novels retrieved successfully", novels);
     }
 

--- a/backend/src/main/java/com/novel/vippro/Controllers/SearchSocketController.java
+++ b/backend/src/main/java/com/novel/vippro/Controllers/SearchSocketController.java
@@ -16,6 +16,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 import com.novel.vippro.DTO.Novel.NovelDTO;
+import com.novel.vippro.DTO.Novel.NovelSearchDTO;
 import com.novel.vippro.Payload.Response.PageResponse;
 import com.novel.vippro.Services.NovelService;
 
@@ -59,7 +60,9 @@ public class SearchSocketController {
 
         Future<?> task = executor.submit(() -> {
             Pageable pageable = PageRequest.of(0, 5); // limit suggestions
-            PageResponse<NovelDTO> page = novelService.searchNovels(query, pageable);
+            NovelSearchDTO searchDTO = new NovelSearchDTO();
+            searchDTO.setKeyword(query);
+            PageResponse<NovelDTO> page = novelService.searchNovels(searchDTO, pageable);
             messagingTemplate.convertAndSend("/topic/search", page.getContent());
         });
 

--- a/backend/src/main/java/com/novel/vippro/DTO/Novel/NovelSearchDTO.java
+++ b/backend/src/main/java/com/novel/vippro/DTO/Novel/NovelSearchDTO.java
@@ -1,0 +1,73 @@
+package com.novel.vippro.DTO.Novel;
+
+import java.util.stream.Stream;
+
+import lombok.Data;
+
+@Data
+public class NovelSearchDTO {
+
+    private String keyword;
+    private String title;
+    private String author;
+    private String category;
+    private String genre;
+
+    public boolean hasFilters() {
+        return Stream.of(keyword, title, author, category, genre)
+                .anyMatch(value -> value != null && !value.trim().isEmpty());
+    }
+
+    public String cacheKey() {
+        return Stream.of(keyword, title, author, category, genre)
+                .map(value -> value == null ? "" : value.trim())
+                .map(value -> value.replace('-', '_'))
+                .reduce((left, right) -> left + "-" + right)
+                .orElse("");
+    }
+
+    public String normalizedKeyword() {
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            return keyword.trim();
+        }
+        return null;
+    }
+
+    public String normalizedTitle() {
+        if (title != null && !title.trim().isEmpty()) {
+            return title.trim();
+        }
+        return null;
+    }
+
+    public String normalizedAuthor() {
+        if (author != null && !author.trim().isEmpty()) {
+            return author.trim();
+        }
+        return null;
+    }
+
+    public String normalizedCategory() {
+        if (category != null && !category.trim().isEmpty()) {
+            return category.trim();
+        }
+        return null;
+    }
+
+    public String normalizedGenre() {
+        if (genre != null && !genre.trim().isEmpty()) {
+            return genre.trim();
+        }
+        return null;
+    }
+
+    public NovelSearchDTO cleanedCopy() {
+        NovelSearchDTO copy = new NovelSearchDTO();
+        copy.setKeyword(normalizedKeyword());
+        copy.setTitle(normalizedTitle());
+        copy.setAuthor(normalizedAuthor());
+        copy.setCategory(normalizedCategory());
+        copy.setGenre(normalizedGenre());
+        return copy;
+    }
+}

--- a/backend/src/main/java/com/novel/vippro/Repository/NovelRepository.java
+++ b/backend/src/main/java/com/novel/vippro/Repository/NovelRepository.java
@@ -47,6 +47,26 @@ public interface NovelRepository extends JpaRepository<Novel, UUID> {
     @Query("SELECT n FROM Novel n WHERE n.titleNormalized LIKE %:keyword%")
     Page<Novel> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
+    @Query("""
+            SELECT DISTINCT n FROM Novel n
+            LEFT JOIN n.categories c
+            LEFT JOIN n.genres g
+            WHERE (:keyword IS NULL OR LOWER(n.titleNormalized) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(n.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(n.author) LIKE LOWER(CONCAT('%', :keyword, '%')))
+              AND (:title IS NULL OR LOWER(n.title) LIKE LOWER(CONCAT('%', :title, '%')))
+              AND (:author IS NULL OR LOWER(n.author) LIKE LOWER(CONCAT('%', :author, '%')))
+              AND (:category IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :category, '%')))
+              AND (:genre IS NULL OR LOWER(g.name) LIKE LOWER(CONCAT('%', :genre, '%')))
+            """)
+    Page<Novel> searchByCriteria(
+            @Param("keyword") String keyword,
+            @Param("title") String title,
+            @Param("author") String author,
+            @Param("category") String category,
+            @Param("genre") String genre,
+            Pageable pageable);
+
     @Query("SELECT n FROM Novel n WHERE n.views > 0 ORDER BY n.views DESC")
     Page<Novel> findAllByOrderByViewsDesc(Pageable pageable);
 

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -2,9 +2,9 @@
 
 import type React from "react"
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
-import { Search, Grid, List, Filter, X } from "lucide-react"
+import { Search, Grid, List, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -12,57 +12,152 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Header } from "@/components/layout/header"
 import { NovelCard } from "@/components/novel/novel-card"
-import { api, type Novel } from "@/lib/api"
+import { api, type Category, type Genre, type Novel } from "@/lib/api"
 import { Pagination } from "@/components/ui/pagination"
+
+type FilterKey = "keyword" | "title" | "author" | "category" | "genre"
+type SearchFilters = Partial<Record<FilterKey, string>>
+
+const filterLabels: Record<FilterKey, string> = {
+  keyword: "Keyword",
+  title: "Title",
+  author: "Author",
+  category: "Category",
+  genre: "Genre",
+}
+
+const filterKeys: FilterKey[] = ["keyword", "title", "author", "category", "genre"]
+
+const cleanFilters = (filters: SearchFilters): SearchFilters => {
+  const cleaned: SearchFilters = {}
+  filterKeys.forEach((key) => {
+    const value = filters[key]
+    if (value && value.trim()) {
+      cleaned[key] = value.trim()
+    }
+  })
+  return cleaned
+}
 
 export default function SearchPage() {
   const [novels, setNovels] = useState<Novel[]>([])
   const [loading, setLoading] = useState(false)
   const [currentPage, setCurrentPage] = useState(0)
   const [totalPages, setTotalPages] = useState(0)
+  const [totalResults, setTotalResults] = useState(0)
   const [sortBy, setSortBy] = useState("updatedAt")
   const [sortDir, setSortDir] = useState("desc")
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
   const [searchQuery, setSearchQuery] = useState("")
-  const [activeFilters, setActiveFilters] = useState<string[]>([])
+  const [titleFilter, setTitleFilter] = useState("")
+  const [authorFilter, setAuthorFilter] = useState("")
+  const [selectedCategory, setSelectedCategory] = useState("")
+  const [selectedGenre, setSelectedGenre] = useState("")
+  const [categories, setCategories] = useState<Category[]>([])
+  const [genres, setGenres] = useState<Genre[]>([])
+  const [lastSubmittedFilters, setLastSubmittedFilters] = useState<SearchFilters | null>(null)
 
   const searchParams = useSearchParams()
   const initialQuery = searchParams.get("q") || ""
 
+  const performSearch = useCallback(
+    async (filters: SearchFilters, page = 0, sortOverride?: { sortBy: string; sortDir: string }) => {
+      const cleaned = cleanFilters(filters)
+
+      if (Object.keys(cleaned).length === 0) {
+        setNovels([])
+        setTotalPages(0)
+        setTotalResults(0)
+        setCurrentPage(0)
+        return
+      }
+
+      setLoading(true)
+      try {
+        const response = await api.searchNovels({
+          ...cleaned,
+          page,
+          size: 20,
+          sortBy: sortOverride?.sortBy ?? sortBy,
+          sortDir: sortOverride?.sortDir ?? sortDir,
+        })
+
+        if (response.success) {
+          setNovels(response.data.content)
+          setTotalPages(response.data.totalPages)
+          setTotalResults(response.data.totalElements)
+          setCurrentPage(response.data.pageNumber ?? page)
+        } else {
+          setNovels([])
+          setTotalPages(0)
+          setTotalResults(0)
+          setCurrentPage(page)
+        }
+      } catch (error) {
+        console.error("Failed to search novels:", error)
+        setNovels([])
+        setTotalPages(0)
+        setTotalResults(0)
+        setCurrentPage(page)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [sortBy, sortDir]
+  )
+
+  useEffect(() => {
+    const fetchTaxonomies = async () => {
+      try {
+        const [categoryResponse, genreResponse] = await Promise.all([
+          api.getCategories(),
+          api.getGenres(),
+        ])
+
+        if (categoryResponse.success) {
+          setCategories(categoryResponse.data)
+        }
+        if (genreResponse.success) {
+          setGenres(genreResponse.data)
+        }
+      } catch (error) {
+        console.error("Failed to load filter data:", error)
+      }
+    }
+
+    void fetchTaxonomies()
+  }, [])
+
   useEffect(() => {
     if (initialQuery) {
       setSearchQuery(initialQuery)
-      performSearch(initialQuery)
+      const initialFilters = cleanFilters({ keyword: initialQuery })
+      setLastSubmittedFilters(initialFilters)
+      void performSearch(initialFilters, 0)
     }
-  }, [initialQuery, currentPage, sortBy, sortDir])
-
-  const performSearch = async (query: string) => {
-    if (!query.trim()) return
-
-    setLoading(true)
-    try {
-      const response = await api.searchNovels(query, {
-        page: currentPage,
-        size: 20,
-        sortBy,
-        sortDir,
-      })
-
-      if (response.success) {
-        setNovels(response.data.content)
-        setTotalPages(response.data.totalPages)
-      }
-    } catch (error) {
-      console.error("Failed to search novels:", error)
-    } finally {
-      setLoading(false)
-    }
-  }
+  }, [initialQuery, performSearch])
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
+    const filters: SearchFilters = {
+      keyword: searchQuery,
+      title: titleFilter,
+      author: authorFilter,
+      category: selectedCategory,
+      genre: selectedGenre,
+    }
+    const cleaned = cleanFilters(filters)
+    if (Object.keys(cleaned).length === 0) {
+      setLastSubmittedFilters(null)
+      setNovels([])
+      setTotalPages(0)
+      setTotalResults(0)
+      setCurrentPage(0)
+      return
+    }
+    setLastSubmittedFilters(cleaned)
     setCurrentPage(0)
-    performSearch(searchQuery)
+    void performSearch(cleaned, 0)
   }
 
   const handleSortChange = (value: string) => {
@@ -70,20 +165,72 @@ export default function SearchPage() {
     setSortBy(field)
     setSortDir(direction)
     setCurrentPage(0)
-  }
-
-  const addFilter = (filter: string) => {
-    if (!activeFilters.includes(filter)) {
-      setActiveFilters([...activeFilters, filter])
+    if (lastSubmittedFilters) {
+      void performSearch(lastSubmittedFilters, 0, { sortBy: field, sortDir: direction })
     }
   }
 
-  const removeFilter = (filter: string) => {
-    setActiveFilters(activeFilters.filter((f) => f !== filter))
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page)
+    if (lastSubmittedFilters) {
+      void performSearch(lastSubmittedFilters, page)
+    }
+  }
+
+  const activeFilters = useMemo(() => {
+    if (!lastSubmittedFilters) return []
+    return (Object.entries(lastSubmittedFilters) as [FilterKey, string][]).map(([key, value]) => ({
+      key,
+      label: `${filterLabels[key]}: ${value}`,
+    }))
+  }, [lastSubmittedFilters])
+
+  const hasSubmittedFilters = activeFilters.length > 0
+
+  const removeFilter = (key: FilterKey) => {
+    if (!lastSubmittedFilters) return
+
+    const updatedFilters: SearchFilters = { ...lastSubmittedFilters }
+    delete updatedFilters[key]
+
+    if (key === "keyword") {
+      setSearchQuery("")
+    } else if (key === "title") {
+      setTitleFilter("")
+    } else if (key === "author") {
+      setAuthorFilter("")
+    } else if (key === "category") {
+      setSelectedCategory("")
+    } else if (key === "genre") {
+      setSelectedGenre("")
+    }
+
+    const cleaned = cleanFilters(updatedFilters)
+    if (Object.keys(cleaned).length === 0) {
+      setLastSubmittedFilters(null)
+      setNovels([])
+      setTotalPages(0)
+      setTotalResults(0)
+      setCurrentPage(0)
+      return
+    }
+
+    setLastSubmittedFilters(cleaned)
+    setCurrentPage(0)
+    void performSearch(cleaned, 0)
   }
 
   const clearAllFilters = () => {
-    setActiveFilters([])
+    setSearchQuery("")
+    setTitleFilter("")
+    setAuthorFilter("")
+    setSelectedCategory("")
+    setSelectedGenre("")
+    setLastSubmittedFilters(null)
+    setNovels([])
+    setTotalPages(0)
+    setTotalResults(0)
+    setCurrentPage(0)
   }
 
   return (
@@ -105,43 +252,69 @@ export default function SearchPage() {
             </div>
 
             {/* Search Form */}
-            <form onSubmit={handleSearch} className="flex gap-2">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search by title, author, or keywords..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10"
-                />
+            <form onSubmit={handleSearch} className="space-y-3">
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Search keywords across the library..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="pl-10"
+                  />
+                </div>
+                <Button type="submit" disabled={loading}>
+                  {loading ? "Searching..." : "Search"}
+                </Button>
               </div>
-              <Button type="submit" disabled={loading}>
-                {loading ? "Searching..." : "Search"}
-              </Button>
+
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <Input
+                  placeholder="Filter by title"
+                  value={titleFilter}
+                  onChange={(e) => setTitleFilter(e.target.value)}
+                />
+                <Input
+                  placeholder="Filter by author"
+                  value={authorFilter}
+                  onChange={(e) => setAuthorFilter(e.target.value)}
+                />
+                <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="All categories" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">All categories</SelectItem>
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={category.name}>
+                        {category.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select value={selectedGenre} onValueChange={setSelectedGenre}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="All genres" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">All genres</SelectItem>
+                    {genres.map((genre) => (
+                      <SelectItem key={genre.id} value={genre.name}>
+                        {genre.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </form>
           </div>
 
           {/* Filters and Controls */}
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div className="flex flex-wrap items-center gap-2">
-              <Button variant="outline" size="sm" onClick={() => addFilter("completed")}>
-                <Filter className="h-4 w-4 mr-1" />
-                Completed
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => addFilter("ongoing")}>
-                <Filter className="h-4 w-4 mr-1" />
-                Ongoing
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => addFilter("high-rated")}>
-                <Filter className="h-4 w-4 mr-1" />
-                High Rated
-              </Button>
-
-              {activeFilters.length > 0 && (
-                <Button variant="ghost" size="sm" onClick={clearAllFilters} className="text-muted-foreground">
-                  Clear All
-                </Button>
-              )}
+            <div className="text-sm text-muted-foreground">
+              {hasSubmittedFilters
+                ? `Showing ${novels.length} of ${totalResults} results`
+                : "Use the filters above to start your search."}
             </div>
 
             <div className="flex items-center space-x-2">
@@ -179,14 +352,17 @@ export default function SearchPage() {
           </div>
 
           {/* Active Filters */}
-          {activeFilters.length > 0 && (
-            <div className="flex flex-wrap gap-2">
+          {hasSubmittedFilters && (
+            <div className="flex flex-wrap items-center gap-2">
               {activeFilters.map((filter) => (
-                <Badge key={filter} variant="secondary" className="flex items-center gap-1">
-                  {filter}
-                  <X className="h-3 w-3 cursor-pointer" onClick={() => removeFilter(filter)} />
+                <Badge key={filter.key} variant="secondary" className="flex items-center gap-1">
+                  {filter.label}
+                  <X className="h-3 w-3 cursor-pointer" onClick={() => removeFilter(filter.key)} />
                 </Badge>
               ))}
+              <Button variant="ghost" size="sm" onClick={clearAllFilters} className="text-muted-foreground">
+                Clear All
+              </Button>
             </div>
           )}
 
@@ -210,22 +386,24 @@ export default function SearchPage() {
                 </Card>
               ))}
             </div>
-          ) : !initialQuery && !searchQuery ? (
-            <div className="text-center py-12">
-              <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <p className="text-muted-foreground">Enter a search term to find novels</p>
-            </div>
-          ) : novels.length === 0 ? (
-            <div className="text-center py-12">
-              <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <p className="text-muted-foreground">No novels found for "{initialQuery || searchQuery}"</p>
-              <p className="text-sm text-muted-foreground mt-2">Try different keywords or check your spelling</p>
-            </div>
-          ) : (
-            <>
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-muted-foreground">Found {novels.length} novels</p>
+            ) : !hasSubmittedFilters ? (
+              <div className="text-center py-12">
+                <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                <p className="text-muted-foreground">Enter search details to find novels</p>
               </div>
+            ) : novels.length === 0 ? (
+              <div className="text-center py-12">
+                <Search className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                <p className="text-muted-foreground">No novels matched the selected filters</p>
+                <p className="text-sm text-muted-foreground mt-2">Try adjusting or clearing your filters</p>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    Showing {novels.length} of {totalResults} results
+                  </p>
+                </div>
 
               <div
                 className={`grid gap-6 ${
@@ -242,15 +420,15 @@ export default function SearchPage() {
           )}
 
           {/* Pagination */}
-          {totalPages > 1 && (
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={setCurrentPage}
-              showPageNumbers={true}
-              className="mt-8"
-            />
-          )}
+            {totalPages > 1 && (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+                showPageNumbers={true}
+                className="mt-8"
+              />
+            )}
         </div>
       </main>
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -422,24 +422,39 @@ class ApiClient {
     }
 
     async searchNovels(
-        keyword: string,
         params: {
+            keyword?: string;
+            title?: string;
+            author?: string;
+            category?: string;
+            genre?: string;
             page?: number;
             size?: number;
             sortBy?: string;
             sortDir?: string;
         } = {}
     ) {
-        const searchParams = new URLSearchParams({ keyword });
+        const searchParams = new URLSearchParams();
         Object.entries(params).forEach(([key, value]) => {
-            if (value !== undefined) {
-                searchParams.append(key, value.toString());
+            if (value !== undefined && value !== null) {
+                const stringValue = value.toString().trim();
+                if (stringValue.length > 0) {
+                    searchParams.append(key, stringValue);
+                }
             }
         });
 
         return this.request<PageResponse<Novel>>(
-            `/api/novels/search?${searchParams}`
+            `/api/novels/search?${searchParams.toString()}`
         );
+    }
+
+    async getCategories() {
+        return this.request<Category[]>("/api/novels/categories");
+    }
+
+    async getGenres() {
+        return this.request<Genre[]>("/api/novels/genres");
     }
 
     async getNovelsByCategory(


### PR DESCRIPTION
## Summary
- add a dedicated `NovelSearchDTO` and expand service/repository logic so searches can combine keyword, title, author, category, and genre filters with Elasticsearch and database fallbacks
- expose the richer filtering from both the REST controller and WebSocket search endpoint
- update the API client and search page UI to surface advanced filter controls and display active filters/results counts